### PR TITLE
ux extractor/injector: support public fields

### DIFF
--- a/teamapps-ux/src/main/java/org/teamapps/data/extract/BeanPropertyExtractor.java
+++ b/teamapps-ux/src/main/java/org/teamapps/data/extract/BeanPropertyExtractor.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,9 +32,18 @@ import java.util.concurrent.ConcurrentHashMap;
 public class BeanPropertyExtractor<RECORD> implements PropertyExtractor<RECORD> {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(BeanPropertyExtractor.class);
-	private static final Map<ClassAndPropertyName, ValueExtractor> gettersByClassAndPropertyName = new ConcurrentHashMap<>();
+	private static final Map<ClassAndPropertyName, ValueExtractor> valueExtractorsByClassAndPropertyName = new ConcurrentHashMap<>();
 
 	private final Map<String, ValueExtractor<RECORD>> customExtractors = new HashMap<>(0);
+	private final boolean fallbackToFields;
+
+	public BeanPropertyExtractor() {
+		this(false);
+	}
+
+	public BeanPropertyExtractor(boolean fallbackToFields) {
+		this.fallbackToFields = fallbackToFields;
+	}
 
 	@Override
 	public Object getValue(RECORD record, String propertyName) {
@@ -47,8 +56,8 @@ public class BeanPropertyExtractor<RECORD> implements PropertyExtractor<RECORD> 
 		if (valueExtractor != null) {
 			return valueExtractor;
 		} else {
-			return gettersByClassAndPropertyName.computeIfAbsent(
-					new ClassAndPropertyName(clazz, propertyName),
+			return valueExtractorsByClassAndPropertyName.computeIfAbsent(
+					new ClassAndPropertyName(clazz, propertyName, fallbackToFields),
 					classAndPropertyName -> createValueExtractor(classAndPropertyName)
 			);
 		}
@@ -56,23 +65,16 @@ public class BeanPropertyExtractor<RECORD> implements PropertyExtractor<RECORD> 
 
 	private ValueExtractor<RECORD> createValueExtractor(ClassAndPropertyName classAndPropertyName) {
 		Method getter = ReflectionUtil.findGetter(classAndPropertyName.clazz, classAndPropertyName.propertyName);
-		Field field = ReflectionUtil.findField(classAndPropertyName.clazz, classAndPropertyName.propertyName);
-		return (record) -> {
-			if (getter != null) {
-				return ReflectionUtil.invokeMethod(record, getter);
-			} else {
-				if (field != null) {
-					try {
-						return field.get(record);
-					} catch (IllegalAccessException ex) {
-						LOGGER.debug("Could not access field for property {} on class {}!", classAndPropertyName.propertyName, record.getClass().getCanonicalName());
-					}
-				} else {
-					LOGGER.debug("Could not find getter or field for property {} on class {}!", classAndPropertyName.propertyName, record.getClass().getCanonicalName());
-				}
+		if (getter != null) {
+			return record -> ReflectionUtil.invokeMethod(record, getter);
+		} else if (fallbackToFields) {
+			Field field = ReflectionUtil.findField(classAndPropertyName.clazz, classAndPropertyName.propertyName);
+			if (field != null) {
+				return record -> ReflectionUtil.readField(record, field, true);
 			}
-			return null;
-		};
+		}
+		LOGGER.debug("Could not find getter " + (fallbackToFields ? "or field " : "") + "for property {} on class {}!", classAndPropertyName.propertyName, classAndPropertyName.getClass().getCanonicalName());
+		return record -> null;
 	}
 
 	public BeanPropertyExtractor<RECORD> addProperty(String propertyName, ValueExtractor<RECORD> valueExtractor) {

--- a/teamapps-ux/src/main/java/org/teamapps/data/extract/BeanPropertyInjector.java
+++ b/teamapps-ux/src/main/java/org/teamapps/data/extract/BeanPropertyInjector.java
@@ -25,6 +25,7 @@ import org.teamapps.util.ReflectionUtil;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -69,7 +70,7 @@ public class BeanPropertyInjector<RECORD> implements PropertyInjector<RECORD> {
 			return (record, value) -> ReflectionUtil.invokeMethod(record, setter, value);
 		} else if (fallbackToFields) {
 			Field field = ReflectionUtil.findField(classAndPropertyName.clazz, classAndPropertyName.propertyName);
-			if (field != null) {
+			if (field != null && !Modifier.isFinal(field.getModifiers())) {
 				return (record, value) -> ReflectionUtil.setField(record, field, value, true);
 			}
 		}

--- a/teamapps-ux/src/main/java/org/teamapps/data/extract/BeanPropertyInjector.java
+++ b/teamapps-ux/src/main/java/org/teamapps/data/extract/BeanPropertyInjector.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,6 +35,15 @@ public class BeanPropertyInjector<RECORD> implements PropertyInjector<RECORD> {
 	private static final Map<ClassAndPropertyName, ValueInjector> settersByClassAndPropertyName = new ConcurrentHashMap<>();
 
 	private final Map<String, ValueInjector> customInjectors = new HashMap<>(0);
+	private final boolean fallbackToFields;
+
+	public BeanPropertyInjector() {
+		this(false);
+	}
+
+	public BeanPropertyInjector(boolean fallbackToFields) {
+		this.fallbackToFields = fallbackToFields;
+	}
 
 	@Override
 	public void setValue(RECORD record, String propertyName, Object value) {
@@ -48,7 +57,7 @@ public class BeanPropertyInjector<RECORD> implements PropertyInjector<RECORD> {
 			return ValueInjector;
 		} else {
 			return settersByClassAndPropertyName.computeIfAbsent(
-					new ClassAndPropertyName(clazz, propertyName),
+					new ClassAndPropertyName(clazz, propertyName, fallbackToFields),
 					classAndPropertyName -> createValueInjector(classAndPropertyName)
 			);
 		}
@@ -56,21 +65,16 @@ public class BeanPropertyInjector<RECORD> implements PropertyInjector<RECORD> {
 
 	private ValueInjector<RECORD, ?> createValueInjector(ClassAndPropertyName classAndPropertyName) {
 		Method setter = ReflectionUtil.findSetter(classAndPropertyName.clazz, classAndPropertyName.propertyName);
-		Field field = ReflectionUtil.findField(classAndPropertyName.clazz, classAndPropertyName.propertyName);
-		return (record, value) -> {
-			if (setter != null) {
-				ReflectionUtil.invokeMethod(record, setter, value);
-			} else {
-				if (field != null) {
-					try {
-						field.set(record, value);
-					} catch (IllegalAccessException ex) {
-						LOGGER.debug("Could not access field for property {} on class {}!", classAndPropertyName.propertyName, record.getClass().getCanonicalName());
-					}
-				} else {
-					LOGGER.debug("Could not find setter or field for property {} on class {}!", classAndPropertyName.propertyName, record.getClass().getCanonicalName());
-				}
+		if (setter != null) {
+			return (record, value) -> ReflectionUtil.invokeMethod(record, setter, value);
+		} else if (fallbackToFields) {
+			Field field = ReflectionUtil.findField(classAndPropertyName.clazz, classAndPropertyName.propertyName);
+			if (field != null) {
+				return (record, value) -> ReflectionUtil.setField(record, field, value, true);
 			}
+		}
+		LOGGER.debug("Could not find setter or field for property {} on class {}!", classAndPropertyName.propertyName, classAndPropertyName.getClass().getCanonicalName());
+		return (record, value) -> {
 		};
 	}
 

--- a/teamapps-ux/src/main/java/org/teamapps/data/extract/ClassAndPropertyName.java
+++ b/teamapps-ux/src/main/java/org/teamapps/data/extract/ClassAndPropertyName.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,36 +19,29 @@
  */
 package org.teamapps.data.extract;
 
-class ClassAndPropertyName {
-	final Class clazz;
-	final String propertyName;
+import java.util.Objects;
 
-	public ClassAndPropertyName(Class clazz, String propertyName) {
+class ClassAndPropertyName {
+	final Class<?> clazz;
+	final String propertyName;
+	final boolean fallbackToFields;
+
+	public ClassAndPropertyName(Class<?> clazz, String propertyName, boolean fallbackToFields) {
 		this.clazz = clazz;
 		this.propertyName = propertyName;
+		this.fallbackToFields = fallbackToFields;
 	}
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
 		ClassAndPropertyName that = (ClassAndPropertyName) o;
-
-		if (!clazz.equals(that.clazz)) {
-			return false;
-		}
-		return propertyName.equals(that.propertyName);
+		return fallbackToFields == that.fallbackToFields && Objects.equals(clazz, that.clazz) && Objects.equals(propertyName, that.propertyName);
 	}
 
 	@Override
 	public int hashCode() {
-		int result = clazz.hashCode();
-		result = 31 * result + propertyName.hashCode();
-		return result;
+		return Objects.hash(clazz, propertyName, fallbackToFields);
 	}
 }

--- a/teamapps-ux/src/main/java/org/teamapps/util/ReflectionUtil.java
+++ b/teamapps-ux/src/main/java/org/teamapps/util/ReflectionUtil.java
@@ -49,6 +49,15 @@ public class ReflectionUtil {
 		return matchingFields;
 	}
 
+	public static Field findField(Class<?> clazz, Predicate<Field> predicate) {
+		List<Field> fields = findFields(clazz, predicate);
+		return fields.size() > 0 ? fields.get(0) : null;
+	}
+
+	public static Field findField(Class<?> clazz, String fieldName) {
+		return findField(clazz, field -> field.getName().equals(fieldName));
+	}
+
 	public static List<Method> findMethods(Class<?> clazz, Predicate<Method> predicate) {
 		List<Method> matchingFields = new ArrayList<>();
 		Class<?> c = clazz;
@@ -65,11 +74,11 @@ public class ReflectionUtil {
 
 	public static Method findMethod(Class<?> clazz, Predicate<Method> predicate) {
 		List<Method> methods = findMethods(clazz, predicate);
-		if (methods.size() > 0) {
-			return methods.get(0);
-		} else {
-			return null;
-		}
+		return methods.size() > 0 ? methods.get(0) : null;
+	}
+
+	public static Method findMethod(Class<?> clazz, String methodName) {
+		return findMethod(clazz, method -> method.getName().equals(methodName));
 	}
 
 	public static Method findMethodByName(Class<?> clazz, String methodName) {
@@ -90,29 +99,13 @@ public class ReflectionUtil {
 	}
 
 	public static <V> V getPropertyValue(Object o, String propertyName) {
-		try {
-			return (V) findGetter(o.getClass(), propertyName).invoke(o);
-		} catch (Exception e) {
-			throw new RuntimeException("Invocation failed.", e);
-		}
+		return (V) invokeMethod(o, findGetter(o.getClass(), propertyName));
 	}
 
-	public static <V> void setProperty(Object o, String propertyName, Object value) {
-		try {
-			findSetter(o.getClass(), propertyName).invoke(o, value);
-		} catch (Exception e) {
-			throw new RuntimeException("Invocation failed.", e);
-		}
+	public static <V> void setProperty(Object o, String propertyName, V value) {
+		invokeMethod(o, findSetter(o.getClass(), propertyName), value);
 	}
 
-	public static Object getFieldValue(Object object, Field field) {
-		try {
-			field.setAccessible(true);
-			return field.get(object);
-		} catch (IllegalAccessException e) {
-			throw new IllegalStateException(e);
-		}
-	}
 
 	public static String toStringUsingReflection(Object o) {
 		if (o == null) {

--- a/teamapps-ux/src/main/java/org/teamapps/util/ReflectionUtil.java
+++ b/teamapps-ux/src/main/java/org/teamapps/util/ReflectionUtil.java
@@ -150,4 +150,26 @@ public class ReflectionUtil {
 			throw new IllegalArgumentException("Could not invoke method " + method.getName() + "(" + expectedParameterTypesString + ") with given parameter types: " + actualParameterTypesString, e);
 		}
 	}
+
+	public static <RECORD> Object readField(RECORD object, Field field, boolean makeAccessibleIfNecessary) {
+		try {
+			if (makeAccessibleIfNecessary && !field.canAccess(object)) {
+				field.setAccessible(true);
+			}
+			return field.get(object);
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static <RECORD> void setField(RECORD object, Field field, Object value, boolean makeAccessibleIfNecessary) {
+		try {
+			if (makeAccessibleIfNecessary && !field.canAccess(object)) {
+				field.setAccessible(true);
+			}
+			field.set(object, value);
+		} catch (IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
+	}
 }

--- a/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyExtractorTest.java
+++ b/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyExtractorTest.java
@@ -27,53 +27,70 @@ public class BeanPropertyExtractorTest {
 
 	@Test
 	public void testGetValue() throws Exception {
-		BeanPropertyExtractor<Object> extractor = new BeanPropertyExtractor<>();
+		BeanPropertyExtractor<A> extractor = new BeanPropertyExtractor<>();
 		Object value = extractor.getValue(new A(), "q");
 		assertEquals("qValue", value);
 	}
 
 	@Test
 	public void testWontGetPrivateFieldValue() throws Exception {
-		BeanPropertyExtractor<Object> extractor = new BeanPropertyExtractor<>();
-		Object value = extractor.getValue(new A(), "r");
+		BeanPropertyExtractor<A> extractor = new BeanPropertyExtractor<>();
+		Object value = extractor.getValue(new A(), "publicField");
 		assertNull(value);
 		// see debug log!
 	}
 
 	@Test
+	public void testValueExtractorsGetCachedSeparatelyDependingOnFallbackToFields() throws Exception {
+		BeanPropertyExtractor<A> extractor = new BeanPropertyExtractor<>();
+		assertNull(extractor.getValue(new A(), "x"));
+		BeanPropertyExtractor<A> extractor2 = new BeanPropertyExtractor<>(true);
+		assertEquals("xValue", extractor2.getValue(new A(), "x"));
+	}
+
+	@Test
 	public void testGetPublicFieldValue() throws Exception {
-		BeanPropertyExtractor<Object> extractor = new BeanPropertyExtractor<>();
-		Object value = extractor.getValue(new A(), "i");
+		BeanPropertyExtractor<A> extractor = new BeanPropertyExtractor<>(true);
+		Object value = extractor.getValue(new A(), "publicField");
 		assertEquals(1337, value);
 	}
 
 	@Test
+	public void testGetPrivateFieldValue() throws Exception {
+		BeanPropertyExtractor<A> extractor = new BeanPropertyExtractor<>(true);
+		Object value = extractor.getValue(new A(), "privateField");
+		assertEquals(2337, value);
+	}
+
+	@Test
 	public void testGetsBooleanGetter() throws Exception {
-		BeanPropertyExtractor<Object> extractor = new BeanPropertyExtractor<>();
+		BeanPropertyExtractor<A> extractor = new BeanPropertyExtractor<>();
 		Object value = extractor.getValue(new A(), "s");
 		assertEquals(true, value);
 	}
 
 	@Test
-	public void testAddCustomPropertyExtractor() throws Exception {
-		BeanPropertyExtractor<Object> extractor = new BeanPropertyExtractor<>();
+	public void testAddCustomValueExtractor() throws Exception {
+		BeanPropertyExtractor<A> extractor = new BeanPropertyExtractor<>();
 		extractor.addProperty("blah", (object) -> "blahValue");
 		Object value = extractor.getValue(new A(), "blah");
 		assertEquals("blahValue", value);
 	}
 
 	@Test
-	public void testAddCustomPropertyExtractorOverwritesProperty() throws Exception {
-		BeanPropertyExtractor<Object> extractor = new BeanPropertyExtractor<>();
+	public void testAddCustomValueExtractorOverwritesProperty() throws Exception {
+		BeanPropertyExtractor<A> extractor = new BeanPropertyExtractor<>();
 		extractor.addProperty("q", (object) -> "overwrittenQValue");
 		Object value = extractor.getValue(new A(), "q");
 		assertEquals("overwrittenQValue", value);
 	}
 
 	public static class A {
-		private String q = "qValue";
-		private String r = "rValue";
-		public int i = 1337;
+		private final String q = "qValue";
+		private final String r = "rValue";
+		public int publicField = 1337;
+		private final int privateField = 2337;
+		private final String x = "xValue";
 
 		public String getQ() {
 			return q;

--- a/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyExtractorTest.java
+++ b/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyExtractorTest.java
@@ -33,11 +33,18 @@ public class BeanPropertyExtractorTest {
 	}
 
 	@Test
-	public void testWontGetFieldValue() throws Exception {
+	public void testWontGetPrivateFieldValue() throws Exception {
 		BeanPropertyExtractor<Object> extractor = new BeanPropertyExtractor<>();
 		Object value = extractor.getValue(new A(), "r");
 		assertNull(value);
 		// see debug log!
+	}
+
+	@Test
+	public void testGetPublicFieldValue() throws Exception {
+		BeanPropertyExtractor<Object> extractor = new BeanPropertyExtractor<>();
+		Object value = extractor.getValue(new A(), "i");
+		assertEquals(1337, value);
 	}
 
 	@Test
@@ -66,6 +73,7 @@ public class BeanPropertyExtractorTest {
 	public static class A {
 		private String q = "qValue";
 		private String r = "rValue";
+		public int i = 1337;
 
 		public String getQ() {
 			return q;
@@ -75,5 +83,5 @@ public class BeanPropertyExtractorTest {
 			return true;
 		}
 	}
-	
+
 }

--- a/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyInjectorTest.java
+++ b/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyInjectorTest.java
@@ -77,6 +77,7 @@ public class BeanPropertyInjectorTest {
 		assertEquals("blub", record.custom);
 	}
 
+	@SuppressWarnings("FieldMayBeFinal")
 	public static class A {
 		private String q = "qValue";
 		public int publicField = 1337;

--- a/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyInjectorTest.java
+++ b/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyInjectorTest.java
@@ -1,0 +1,84 @@
+package org.teamapps.data.extract;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BeanPropertyInjectorTest {
+
+	@Test
+	public void testSetValueUsingProperty() throws Exception {
+		BeanPropertyInjector<A> injector = new BeanPropertyInjector<>();
+		A record = new A();
+		injector.setValue(record, "q", "newQValue");
+		assertEquals("newQValue", record.q);
+	}
+
+	@Test
+	public void testNotSetPublicFieldValue() throws Exception {
+		BeanPropertyInjector<A> injector = new BeanPropertyInjector<>();
+		A record = new A();
+		injector.setValue(record, "publicField", 9);
+		assertEquals(1337, record.publicField);
+	}
+
+	@Test
+	public void testSetPublicFieldValue() throws Exception {
+		BeanPropertyInjector<A> injector = new BeanPropertyInjector<>(true);
+		A record = new A();
+		injector.setValue(record, "publicField", 9);
+		assertEquals(9, record.publicField);
+	}
+
+	@Test
+	public void testValueInjectorsAreCachedSeparatelyDependingOnFallbackToFields() throws Exception {
+		BeanPropertyInjector<A> injector = new BeanPropertyInjector<>();
+		A record = new A();
+		injector.setValue(record, "x", "foo");
+		assertEquals("xValue", record.x);
+		BeanPropertyInjector<A> injector2 = new BeanPropertyInjector<>(true);
+		injector2.setValue(record, "x", "bar");
+		assertEquals("bar", record.x);
+	}
+
+	@Test
+	public void testSetPrivateFieldValue() throws Exception {
+		BeanPropertyInjector<A> injector = new BeanPropertyInjector<>(true);
+		A record = new A();
+		injector.setValue(record, "privateField", 7);
+		assertEquals(7, record.privateField);
+	}
+
+	@Test
+	public void testAddCustomValueInjector() throws Exception {
+		BeanPropertyInjector<A> injector = new BeanPropertyInjector<>();
+		injector.addProperty("blah", (record, value) -> record.custom = (String) value);
+		A record = new A();
+		injector.setValue(record, "blah", "blub");
+		assertEquals("blub", record.custom);
+	}
+
+	@Test
+	public void testAddCustomValueInjectorOverwritesProperty() throws Exception {
+		BeanPropertyInjector<A> injector = new BeanPropertyInjector<>();
+		injector.addProperty("q", (record, value) -> record.custom = (String) value);
+		A record = new A();
+		injector.setValue(record, "q", "blub");
+		assertEquals("qValue", record.q);
+		assertEquals("blub", record.custom);
+	}
+
+	public static class A {
+		private String q = "qValue";
+		public int publicField = 1337;
+		private final int privateField = 2337;
+		private String custom;
+		private final String x = "xValue";
+
+		public void setQ(String q) {
+			this.q = q;
+		}
+
+	}
+
+}

--- a/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyInjectorTest.java
+++ b/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyInjectorTest.java
@@ -80,9 +80,9 @@ public class BeanPropertyInjectorTest {
 	public static class A {
 		private String q = "qValue";
 		public int publicField = 1337;
-		private final int privateField = 2337;
+		private int privateField = 2337;
 		private String custom;
-		private final String x = "xValue";
+		private String x = "xValue";
 		private final String finalField = "finalFieldValue";
 
 		public void setQ(String q) {

--- a/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyInjectorTest.java
+++ b/teamapps-ux/src/test/java/org/teamapps/data/extract/BeanPropertyInjectorTest.java
@@ -1,5 +1,6 @@
 package org.teamapps.data.extract;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -42,6 +43,14 @@ public class BeanPropertyInjectorTest {
 	}
 
 	@Test
+	public void testDoesNotChangeFinalFields() throws Exception {
+		BeanPropertyInjector<A> injector = new BeanPropertyInjector<>(true);
+		A record = new A();
+		injector.setValue(record, "finalField", "foo");
+		Assert.assertEquals("finalFieldValue", record.finalField);
+	}
+
+	@Test
 	public void testSetPrivateFieldValue() throws Exception {
 		BeanPropertyInjector<A> injector = new BeanPropertyInjector<>(true);
 		A record = new A();
@@ -74,6 +83,7 @@ public class BeanPropertyInjectorTest {
 		private final int privateField = 2337;
 		private String custom;
 		private final String x = "xValue";
+		private final String finalField = "finalFieldValue";
 
 		public void setQ(String q) {
 			this.q = q;


### PR DESCRIPTION
- For BeanPropertyExtractor and BeanPropertyInjector support accessing
  **public** fields (in case no matching property exists)
- Add findField methods to ReflectionUtil
- Remove getFieldValue from Reflection Util because it is implicit in
  modifying access and otherwise is most trivial
- Extend BeanPropertyExtractor Test

Of course a POJO/Bean has to have properties by convention, but the current implementation enforces quite some overhead.
I vouch to give the developer the freedom to decide whether they want the flexibility of properties or favour the brevity of public fields.