### PR TITLE
Routing: Evaluation whether Router matches path prefix should use absolute path prefix.

### DIFF
--- a/teamapps-ux/src/main/java/org/teamapps/ux/session/SessionContext.java
+++ b/teamapps-ux/src/main/java/org/teamapps/ux/session/SessionContext.java
@@ -254,7 +254,7 @@ public class SessionContext {
 				pathChangeOperation = PUSH;
 			}
 			queryParamNamesWorthStatePush.addAll(routeChangeInfo.getQueryParamNamesWorthStatePush());
-			String pathPrefix = routeChangeInfo.getRoute().getPath();
+			String pathPrefix = route.getPath();
 			boolean addsToPath = !isEmptyPath(pathPrefix);
 			// TODO #performance check efficiency and improve
 			router = addsToPath ? this.routers.stream().filter(r -> r.matchesPathPrefix(pathPrefix)).findFirst().orElse(null) : null;


### PR DESCRIPTION
Fixes invoking of path supplier for updating URL in browser's address bar.