### PR TITLE
Migrate to Jakarta EE 10 and update all related libs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 14
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
     </modules>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <maven-assembly-plugin-version>3.0.0</maven-assembly-plugin-version>
@@ -208,13 +208,6 @@
                 <artifactId>annotations</artifactId>
                 <version>13.0</version>
             </dependency>
-
-            <dependency>
-                <groupId>javax</groupId>
-                <artifactId>javaee-web-api</artifactId>
-                <version>8.0</version>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 

--- a/teamapps-application-management/pom.xml
+++ b/teamapps-application-management/pom.xml
@@ -95,6 +95,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/teamapps-server-jetty-embedded/pom.xml
+++ b/teamapps-server-jetty-embedded/pom.xml
@@ -34,13 +34,13 @@
     </developers>
 
     <properties>
-        <jetty.version>11.0.13</jetty.version>
+        <jetty.version>12.0.2</jetty.version>
     </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp</artifactId>
+            <groupId>org.eclipse.jetty.ee10</groupId>
+            <artifactId>jetty-ee10-webapp</artifactId>
             <version>${jetty.version}</version>
             <exclusions>
                 <exclusion>
@@ -50,8 +50,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-jakarta-server</artifactId>
+            <groupId>org.eclipse.jetty.ee10.websocket</groupId>
+            <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
             <version>${jetty.version}</version>
             <exclusions>
                 <exclusion>

--- a/teamapps-server-undertow-embedded/pom.xml
+++ b/teamapps-server-undertow-embedded/pom.xml
@@ -34,18 +34,18 @@
     </developers>
 
     <properties>
-        <undertow.version>2.2.20.Final</undertow.version>
+        <undertow.version>2.3.8.Final</undertow.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet-jakarta</artifactId>
+            <artifactId>undertow-servlet</artifactId>
             <version>${undertow.version}</version>
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
-            <artifactId>undertow-websockets-jsr-jakarta</artifactId>
+            <artifactId>undertow-websockets-jsr</artifactId>
             <version>${undertow.version}</version>
         </dependency>
         <dependency>

--- a/teamapps-ux/pom.xml
+++ b/teamapps-ux/pom.xml
@@ -21,7 +21,7 @@
         </license>
     </licenses>
     <properties>
-        <jersey.version>3.0.4</jersey.version>
+        <jersey.version>3.0.11</jersey.version>
     </properties>
     <developers>
         <developer>

--- a/teamapps-ux/pom.xml
+++ b/teamapps-ux/pom.xml
@@ -21,7 +21,7 @@
         </license>
     </licenses>
     <properties>
-        <jersey.version>3.0.11</jersey.version>
+        <jersey.version>3.1.3</jersey.version>
     </properties>
     <developers>
         <developer>
@@ -84,19 +84,22 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
-<!--        <dependency>-->
-<!--            <groupId>javax</groupId>-->
-<!--            <artifactId>javaee-web-api</artifactId>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version>
+            <version>6.0.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-api</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-client-api</artifactId>
+            <version>2.1.1</version>
             <scope>provided</scope>
         </dependency>
 
@@ -148,17 +151,6 @@
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
             <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <!-- Needed for MediaSoupV3RestClient only! -->
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.4.0-b180830.0359</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Now ready for review, but depends on #102 

Although JEE 10 is compatible with JDK 11, Jetty 12 has upgraded the minimum supported version to  JDK 17, so this comes with a bump to java as well.
