### PR TITLE
Provide support for Jersey 3.0.11+ and upgrade

### DIFF
--- a/teamapps-ux/pom.xml
+++ b/teamapps-ux/pom.xml
@@ -21,7 +21,7 @@
         </license>
     </licenses>
     <properties>
-        <jersey.version>3.0.4</jersey.version>
+        <jersey.version>3.0.11</jersey.version>
     </properties>
     <developers>
         <developer>


### PR DESCRIPTION
Teamapps is using some internal Jersey API that was changed in Jersey 3.0.11 and 3.1.x - https://github.com/eclipse-ee4j/jersey/pull/5349

This PR provides a backwards-compatible way to instantiate Jersey Param converters using reflection. It also upgrades jersey to latest JEE 9.1 release 3.0.11.