### PR TITLE
fixed: invalid CSS keyword prevented correct sizing of background images (in ImageElement / UiImageElement)

### DIFF
--- a/teamapps-client/ts/modules/util/CssFormatUtil.ts
+++ b/teamapps-client/ts/modules/util/CssFormatUtil.ts
@@ -145,7 +145,7 @@ export function createImageSizingCssObject(imageSizing: UiImageSizing): CssPrope
 			backgroundSize = "cover";
 		}
 		return {
-			"backgroundSize": backgroundSize
+			"background-size": backgroundSize
 		}
 	}
 }

--- a/teamapps-ux/src/main/java/org/teamapps/ux/application/ApplicationChangeHandler.java
+++ b/teamapps-ux/src/main/java/org/teamapps/ux/application/ApplicationChangeHandler.java
@@ -63,5 +63,5 @@ public interface ApplicationChangeHandler {
 
     void handleViewWorkspaceToolbarButtonGroupRemoved(ResponsiveApplication application, boolean isActivePerspective, Perspective perspective, View view, ToolbarButtonGroup buttonGroup);
 
-    void handleViewSelect(  View view  );
+    void handleViewSelect(View view);
 }

--- a/teamapps-ux/src/main/java/org/teamapps/ux/application/ApplicationChangeHandler.java
+++ b/teamapps-ux/src/main/java/org/teamapps/ux/application/ApplicationChangeHandler.java
@@ -63,5 +63,5 @@ public interface ApplicationChangeHandler {
 
     void handleViewWorkspaceToolbarButtonGroupRemoved(ResponsiveApplication application, boolean isActivePerspective, Perspective perspective, View view, ToolbarButtonGroup buttonGroup);
 
-    void handleViewSelect(View view);
+    void handleViewSelect(  View view  );
 }


### PR DESCRIPTION
Sizing (contain, cover, ...) the background image of HTML elements requires the correct CSS keyword: background-size instead of backgroundSize

See the picture below: background-size of an ImageElement/UiImageElement is set to "contain", but the browser refuses this setting because of the invalid keyword "backgroundSize".

![ImageElement_Bug-Demonstration](https://github.com/user-attachments/assets/4a176171-7095-48e5-ae48-ebf45a32d3cd)
