### PR TITLE
fixed: deleting the selected node of the SimpleTree should never leave a reference on it (returned by getSelectedNode)

### DIFF
--- a/teamapps-ux/src/main/java/org/teamapps/ux/component/tree/SimpleTree.java
+++ b/teamapps-ux/src/main/java/org/teamapps/ux/component/tree/SimpleTree.java
@@ -73,10 +73,14 @@ public class SimpleTree<PAYLOAD> extends Tree<BaseTemplateTreeNode<PAYLOAD>> {
 
 	public void removeNode(BaseTemplateTreeNode<PAYLOAD> node) {
 		getModel().removeNode(node);
+		if (node == getSelectedNode()) {
+			setNoSelectedNode();
+		}
 	}
 
 	public void removeAllNodes() {
 		getModel().removeAllNodes();
+		setNoSelectedNode();
 	}
 
 	public SimpleTreeModel<PAYLOAD> getModel() {
@@ -94,5 +98,9 @@ public class SimpleTree<PAYLOAD> extends Tree<BaseTemplateTreeNode<PAYLOAD>> {
 	@Override
 	public void setEntryTemplate(Template entryTemplate) {
 		setTemplatesByDepth(entryTemplate);
+	}
+
+	public void setNoSelectedNode() {
+		setSelectedNode(null);
 	}
 }


### PR DESCRIPTION
After deleting the selected node of a SimpleTree (with removeNode()) the method getSelectedNode() returns still a reference to the already deleted node!
This pull request provides a proposal for fixing this issue.